### PR TITLE
[WIP]Add asynchronous communication for send a message function

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,15 @@
 $(function() {
   $('.form').on('submit', function(e) {
     e.preventDefault();
-    message = $('.form__message').val();
-    console.log(message);
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      type: "POST",
+      url: url,
+      data: formData,
+      datatype: "json",
+      processData: false,
+      contentType: false
+    });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,7 @@
+$(function() {
+  $('.form').on('submit', function(e) {
+    e.preventDefault();
+    message = $('.form__message').val();
+    console.log(message);
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,15 +1,51 @@
 $(function() {
-  $('.form__message').on('submit', function(e) {
+  function buildHTML(message){
+  var image = `${message.image}` != "null" ?
+  `<img src="${message.image}">` : ``
+  var html  = `<div class="message">
+                 <div class="upper-message">
+                   <div class="upper-message__user-name">
+                     ${message.user_name}
+                   </div>
+                   <div class="upper-message__date">
+                     ${message.created_at}
+                   </div>
+                 </div>
+                 <div class="lower-message">
+                   <p class="lower-message__content">
+                     ${message.content}
+                   </p>
+                   <div class="lower-message__image">
+                     ${image}
+                   </div>
+                 </div>
+               </div>`
+    return html;
+  }
+
+  $('#new_message').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);
-    var href = window.location.href
+    var url = $(this).attr('action')
     $.ajax({
-      url: href,
+      url: url,
       type: "POST",
       data: formData,
       dataType: "json",
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $(".messages").animate({ scrollTop: $(".messages")[0].scrollHeight });
+      $('.form__message').val('');
+      $('.form__submit').prop('disabled', false);
+      $('input[type=file]').val('');
+    })
+    .fail(function(){
+      alert('エラー：メッセージを入力してください');
+      $('.form__submit').prop('disabled', false);
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,15 +1,15 @@
 $(function() {
-  $('.form').on('submit', function(e) {
+  $('.form__message').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);
-    var url = $(this).attr('action')
+    var href = window.location.href
     $.ajax({
+      url: href,
       type: "POST",
-      url: url,
       data: formData,
-      datatype: "json",
+      dataType: "json",
       processData: false,
       contentType: false
-    });
-  });
+    })
+  })
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,7 +11,7 @@ class MessagesController < ApplicationController
     if @message.save
       respond_to do |format|
         format.html { redirect_to group_messages_path(@group) }
-        format.json { render json: @message }
+        format.json
       end
     else
       @messages = @group.messages.includes(:user)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group) }
+        format.json { render json: @message }
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,7 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-        format.html { redirect_to group_messages_path(@group) }
+        format.html
         format.json
       end
     else

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -2,7 +2,7 @@ class ImagesUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [400, 400]
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.user_name  @message.user.name
+json.group      @message.group
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.content    @message.content
 json.image      @message.image.url

--- a/app/views/messages/message.json.jbuilder
+++ b/app/views/messages/message.json.jbuilder
@@ -1,0 +1,5 @@
+json.user_name  @message.user.name
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.content    @message.content
+json.image      @message.image.url
+json.id         @message.id

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
![2 -10-2019 18-49-40](https://user-images.githubusercontent.com/45124040/52532224-b51bfa80-2d64-11e9-9e9a-2cab223e6420.gif)

# WHAT
#### メッセージ送信機能の非同期通信化
- APIの作成
- jsファイルの作成
- フォーム送信時のイベント発火のための記述
- Ajax使用によりmessages#createを作動させるための記述
- respond_toによる処理分岐（HTML/JSON）の記述
- jbuilder使用→作成メッセージをJSON形式で返すための記述
- JSONをdoneメソッドで処理する記述
- HTMLを作成するメソッドの記述
- メッセージ追加および自動スクロールの記述
- 非同期に失敗した場合の処理の記述
- input要素(submit)のdisabledを解除
- アップロード時に選択したファイルをクリアする記述

# WHY
#### 非同期通信の実装
- メッセージ送信時のリダイレクト処理をなくしたり、自動スクロールを追加することで、UXの向上をはかるため
- jbuilderを使用することでjsonの生成を簡素化するため
- メッセージ送信成功時のsubmitボタンが押せなくなる問題の解消のため
- 画像の連続送信防止のため